### PR TITLE
Enable Enter key for nvim-cmp completion and add zsh plugins

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -732,7 +732,7 @@ require('lazy').setup({
 
           -- If you prefer more traditional completion keymaps,
           -- you can uncomment the following lines
-          --['<CR>'] = cmp.mapping.confirm { select = true },
+          ['<CR>'] = cmp.mapping.confirm { select = true },
           --['<Tab>'] = cmp.mapping.select_next_item(),
           --['<S-Tab>'] = cmp.mapping.select_prev_item(),
 

--- a/.zshrc
+++ b/.zshrc
@@ -31,3 +31,13 @@ esac
 
 # Google Cloud SDK — use asdf-managed Python
 export CLOUDSDK_PYTHON=$(asdf which python3)
+export PATH="$HOME/.local/bin:$PATH"
+
+# --- Zsh Plugins ---
+
+# Autosuggestions — grey text inline suggestions from history
+source /usr/local/opt/zsh-autosuggestions/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=#808080"
+
+# Syntax highlighting — colorizes commands as you type
+source /usr/local/opt/zsh-syntax-highlighting/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh


### PR DESCRIPTION
Add CR mapping for nvim-cmp confirm, add zsh-autosuggestions and zsh-syntax-highlighting plugins, and add ~/.local/bin to PATH.